### PR TITLE
feat(server): get vocabulary statuses/notifications by user id

### DIFF
--- a/apps/server/src/module/user/user.controller.ts
+++ b/apps/server/src/module/user/user.controller.ts
@@ -1,30 +1,34 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
 import { UserService } from './user.service';
 import { ResponseMessage } from 'src/decorator/response-message.decorator';
-
+import { Request as ExpressRequest } from 'express';
+import { AuthGuard as JWTGuard } from '../auth/google.guard';
+import { Notification, VocabularyStatus } from '@prisma/client';
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
-  @Get()
-  @ResponseMessage('Get user')
-  getUser() {
-    return [
-      {
-        id: 1,
-        name: 'John Doe',
-        email: 'john.doe@example.com',
-      },
-      {
-        id: 1,
-        name: 'John Doe',
-        email: 'john.doe@example.com',
-      },
-      {
-        id: 1,
-        name: 'John Doe',
-        email: 'john.doe@example.com',
-      },
-    ];
+  @UseGuards(JWTGuard)
+  @Get('notifications')
+  @ResponseMessage('Get user notifications')
+  async getNotifications(@Req() req: ExpressRequest): Promise<Notification[]> {
+    const userId = req['user'].id;
+    if (!userId) {
+      throw new Error('User ID not found');
+    }
+    return this.userService.getNotificationsByUserId(userId);
+  }
+
+  @UseGuards(JWTGuard)
+  @Get('vocabulary-statuses')
+  @ResponseMessage('Get user vocabulary statuses')
+  async getVocabularyStatuses(
+    @Req() req: ExpressRequest,
+  ): Promise<VocabularyStatus[]> {
+    const userId = req['user'].id;
+    if (!userId) {
+      throw new Error('User ID not found');
+    }
+    return this.userService.getVocabularyStatusesByUserId(userId);
   }
 }

--- a/apps/server/src/module/user/user.module.ts
+++ b/apps/server/src/module/user/user.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [UserController],
   providers: [UserService],
 })

--- a/apps/server/src/module/user/user.service.ts
+++ b/apps/server/src/module/user/user.service.ts
@@ -1,4 +1,27 @@
 import { Injectable } from '@nestjs/common';
-
+import { PrismaService } from 'src/prisma/prisma.service';
+import { Notification } from '@prisma/client';
+import { VocabularyStatus } from '@prisma/client';
 @Injectable()
-export class UserService {}
+export class UserService {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async getNotificationsByUserId(userId: string): Promise<Notification[]> {
+    return this.prismaService.notification.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async getVocabularyStatusesByUserId(
+    userId: string,
+  ): Promise<VocabularyStatus[]> {
+    return this.prismaService.vocabularyStatus.findMany({
+      where: { userId },
+      include: {
+        vocabulary: true,
+        notifications: true,
+      },
+    });
+  }
+}

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -1,0 +1,10 @@
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div>{children}</div>
+  );
+}

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const AdminPage = () => {
+  return (
+    <div className='font-bold'>AdminPage</div>
+  )
+}
+
+export default AdminPage


### PR DESCRIPTION
## What does this PR do

resolve #27 #28 
get vocabulary statuses/notifications by user id
## Checklist

- [ ] Tests added (if necessary, is mandatory for bug fixes)
- [ ] Unit tests passed locally
- [ ] phpcs/eslint passed locally
- [ ] Commit messages are [semantic](https://www.conventionalcommits.org/)

## Other information

Any added configuration? Note for migrations? TODO? .etc
