### PR TITLE
feat: update base api vocab status

### DIFF
--- a/apps/server/src/module/vocabulary/dto/create-status.dto.ts
+++ b/apps/server/src/module/vocabulary/dto/create-status.dto.ts
@@ -1,0 +1,29 @@
+/* eslint-disable prettier/prettier */
+import { IsNotEmpty, IsString, IsEnum, IsInt, IsDate } from 'class-validator';
+import { VOCABULARY_STATUS } from '@prisma/client'; // Import the VOCABULARY_STATUS enum from Prisma
+
+export class CreateVocabularyStatusDto {
+  @IsNotEmpty()
+  @IsString()
+  userId: string;
+
+  @IsNotEmpty()
+  @IsString()
+  vocabularyId: string;
+
+  @IsNotEmpty()
+  @IsEnum(VOCABULARY_STATUS)
+  status: VOCABULARY_STATUS;
+
+  @IsNotEmpty()
+  @IsDate()
+  learnedAt: Date;
+
+  @IsNotEmpty()
+  @IsDate()
+  nextReviewAt: Date;
+
+  @IsNotEmpty()
+  @IsInt()
+  reviewStage: number;
+}

--- a/apps/server/src/module/vocabulary/dto/update-status.dto.ts
+++ b/apps/server/src/module/vocabulary/dto/update-status.dto.ts
@@ -1,0 +1,5 @@
+/* eslint-disable prettier/prettier */
+import { PartialType } from '@nestjs/swagger';
+import { CreateVocabularyStatusDto } from './create-status.dto';
+
+export class UpdateVocabularyStatusDto extends PartialType(CreateVocabularyStatusDto) {}

--- a/apps/server/src/module/vocabulary/dto/update-vocabulary.dto.ts
+++ b/apps/server/src/module/vocabulary/dto/update-vocabulary.dto.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { PartialType } from '@nestjs/swagger';
 import { CreateVocabularyDto } from './create-vocabulary.dto';
 

--- a/apps/server/src/module/vocabulary/vocabulary.controller.ts
+++ b/apps/server/src/module/vocabulary/vocabulary.controller.ts
@@ -1,9 +1,11 @@
 /* eslint-disable prettier/prettier */
-import { Body, Controller, Delete, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get,Put, Param, Post, UseGuards } from '@nestjs/common';
 import { VocabularyService } from './vocabulary.service';
 import { AuthGuard as JWTGuard } from '../../guard/google.guard';
 import { AdminAuthGuard } from '../../guard/admin.guard';
 import { CreateVocabularyDto } from './dto/create-vocabulary.dto';
+import { CreateVocabularyStatusDto } from './dto/create-status.dto';
+import { UpdateVocabularyStatusDto } from './dto/update-status.dto';
 @Controller('vocabularies')
 export class VocabularyController {
   constructor(private readonly vocabularyService: VocabularyService) {}
@@ -22,9 +24,9 @@ export class VocabularyController {
   @Get()
   @UseGuards(JWTGuard)
    async getVocabById(
-    @Param('id') id: string,
+    @Param('id') vocabularyId: string,
    ){
-    return this.vocabularyService.getVocabularyById(id);
+    return this.vocabularyService.getVocabularyById(vocabularyId);
    }
   @Post(':lessonId')
   @UseGuards(JWTGuard)
@@ -38,7 +40,41 @@ export class VocabularyController {
   @Delete(':id')
   @UseGuards(JWTGuard)
   @UseGuards(AdminAuthGuard)
-  async deleteVocabulary(@Param('id') id: string) {
-    return this.vocabularyService.deleteVocabulary(id);
+  async deleteVocabulary(@Param('id') vocabularyId: string) {
+    return this.vocabularyService.deleteVocabulary(vocabularyId);
+  }
+
+  @Get('status/:id')
+  @UseGuards(JWTGuard)
+  async getVocabularyStatus(@Param('id') vocabularyId: string) {
+    return this.vocabularyService.getVocabularyStatus(vocabularyId);
+  }
+  @Get('status')
+  @UseGuards(JWTGuard)
+  async getAllVocabularyStatus() {
+    return this.vocabularyService.getAllVocabularyStatus();
+  }
+
+  @Post('status/:id')
+  @UseGuards(JWTGuard)
+  async createVocabularyStatus(
+    @Body() vocabularyStatus: CreateVocabularyStatusDto,
+    @Param('vocabularyId') vocabularyId: string,
+    @Param('userId') userId: string,
+  ) {
+    return this.vocabularyService.createVocabularyStatus(vocabularyStatus, vocabularyId, userId);
+  }
+  @Put('status/:id')
+  @UseGuards(JWTGuard)
+  async updateVocabularyStatus(
+    @Param('id') vocabularyId: string,
+    @Body() vocabularyStatus: UpdateVocabularyStatusDto,
+    ) {
+    return this.vocabularyService.updateVocabularyStatus(vocabularyId, vocabularyStatus);
+  }
+  @Delete('status/:id')
+  @UseGuards(JWTGuard)
+  async deleteVocabularyStatus(@Param('id') vocabularyId: string) {
+    return this.vocabularyService.deleteVocabularyStatus(vocabularyId);
   }
 }

--- a/apps/server/src/module/vocabulary/vocabulary.service.ts
+++ b/apps/server/src/module/vocabulary/vocabulary.service.ts
@@ -2,6 +2,8 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateVocabularyDto } from './dto/create-vocabulary.dto';
+import { CreateVocabularyStatusDto } from './dto/create-status.dto';
+import { UpdateVocabularyStatusDto } from './dto/update-status.dto';
 
 @Injectable()
 export class VocabularyService {
@@ -15,9 +17,9 @@ export class VocabularyService {
   async getALL() {
     return await this.prismaService.vocabulary.findMany();
   }
-  async getVocabularyById(id: string) {
+  async getVocabularyById(vocabularyId: string) {
     return await this.prismaService.vocabulary.findUnique({
-      where: { id },
+      where: { id: vocabularyId },
     });
   }
   async createVocabulary(vocabularyInput: CreateVocabularyDto,lessonId: string) {
@@ -30,9 +32,45 @@ export class VocabularyService {
       }
     });
   }
-  async deleteVocabulary(id: string) {
+  async deleteVocabulary(vocabularyId: string) {
     await this.prismaService.vocabulary.delete({
-      where: { id },
+      where: { id: vocabularyId },
+    });
+  }
+  async getVocabularyStatus(vocabularyId:string){
+    return await this.prismaService.vocabularyStatus.findUnique({
+      where: { id: vocabularyId },
+    });
+  }
+  async getAllVocabularyStatus(){
+    return await this.prismaService.vocabularyStatus.findMany();
+  }
+  async createVocabularyStatus(vocabularyStatus: CreateVocabularyStatusDto, vocabularyId: string,userId: string){
+    return await this.prismaService.vocabularyStatus.create({
+      data: {
+        vocabulary: { connect: { id: vocabularyId } },
+        status: vocabularyStatus.status,
+        learnedAt: new Date(),
+        nextReviewAt: new Date(),
+        reviewStage: 1,
+        user: { connect: { id: userId } }, 
+      }
+    });
+}
+  async updateVocabularyStatus(vocabularyId: string, vocabularyStatus: UpdateVocabularyStatusDto) {
+    return await this.prismaService.vocabularyStatus.update({
+      where: { id: vocabularyId },
+      data: {
+        status: vocabularyStatus.status,
+        learnedAt: new Date(),
+        nextReviewAt: new Date(),
+        reviewStage: 1,
+      }
+    });
+  }
+  async deleteVocabularyStatus(vocabularyId: string) {
+    await this.prismaService.vocabularyStatus.delete({
+      where: { id: vocabularyId },
     });
   }
 }


### PR DESCRIPTION
## What does this PR do
feat: update base api vocab status
resolve #43 
done POST /vocabulary/status: Create a new vocabulary status for a user.
done GET /vocabulary/status: Get all vocabulary statuses.
done GET /vocabulary/status/:id: Get a specific vocabulary status.
done PUT /vocabulary/status/:id: Update a vocabulary status.
done DELETE /vocabulary/status/:id: Delete a vocabulary status.
## Checklist

- [ ] Tests added (if necessary, is mandatory for bug fixes)
- [ ] Unit tests passed locally
- [ ] phpcs/eslint passed locally
- [ ] Commit messages are [semantic](https://www.conventionalcommits.org/)

## Other information

Any added configuration? Note for migrations? TODO? .etc
